### PR TITLE
fix more issues related to unset values parsed from strings

### DIFF
--- a/lreq/lreq.go
+++ b/lreq/lreq.go
@@ -157,10 +157,18 @@ func unmarshalField(
 	strVal, ok := params[param]
 	strVals, okMulti := multiParam[param]
 
+	//fmt.Println(fmt.Sprintf("ok %t", ok))
+	//fmt.Println(fmt.Sprintf("okMulti %t", okMulti))
+	//fmt.Println(fmt.Sprintf("strVal %s", strVal))
+	//fmt.Println(fmt.Sprintf("strVals %+v", strVals))
+	//
+	//fmt.Println(fmt.Sprintf("strVals == nil %t", strVals == nil))
+	//fmt.Println(fmt.Sprintf("len(strVals) < 1) %t", len(strVals) < 1))
+
 	// check for empty / unset values and return no error if so
-	if !ok && !okMulti || (strVal == "" && strVals == nil) {
-		return nil
-	}
+	//if !ok && !okMulti || (strVal == "" && (strVals == nil || len(strVals) < 1) || strVals[0] == "") {
+	//	return nil
+	//}
 
 	//fmt.Println(fmt.Sprintf("param %s", param))
 	//fmt.Println(fmt.Sprintf("params[param] %s", strVal))
@@ -184,6 +192,9 @@ func unmarshalField(
 
 	switch typeField.Kind() {
 	case reflect.Array:
+		if strVal == "" {
+			return nil
+		}
 		objectID, err := primitive.ObjectIDFromHex(strVal)
 		if err != nil {
 			return fmt.Errorf("invalid ObjectID: %s", err)
@@ -252,12 +263,18 @@ func unmarshalField(
 				valueField.Set(intPtr)
 			case reflect.Struct:
 				if typeField.Elem() == reflect.TypeOf(civil.Date{}) {
+					if strVal == "" {
+						return nil
+					}
 					parsedCivil, err := civil.ParseDate(strVal)
 					if err != nil {
 						return err
 					}
 					valueField.Set(reflect.ValueOf(&parsedCivil))
 				} else if typeField.Elem() == reflect.TypeOf(time.Time{}) {
+					if strVal == "" {
+						return nil
+					}
 					parsedTime, err := time.Parse(time.RFC3339, strVal)
 					if err != nil {
 						return err
@@ -271,6 +288,9 @@ func unmarshalField(
 			default:
 				switch typeField.Elem() {
 				case reflect.TypeOf(primitive.ObjectID{}):
+					if strVal == "" {
+						return nil
+					}
 					objectID, err := primitive.ObjectIDFromHex(strVal)
 					if err != nil {
 						return fmt.Errorf("invalid ObjectID: %s", err)
@@ -340,12 +360,18 @@ func unmarshalField(
 	case reflect.Struct:
 		switch valueField.Type() {
 		case reflect.TypeOf(time.Time{}):
+			if strVal == "" {
+				return nil
+			}
 			parsedTime, err := time.Parse(time.RFC3339, strVal)
 			if err != nil {
 				return err
 			}
 			valueField.Set(reflect.ValueOf(parsedTime))
 		case reflect.TypeOf(civil.Date{}):
+			if strVal == "" {
+				return nil
+			}
 			parsedCivil, err := civil.ParseDate(strVal)
 			if err != nil {
 				return err

--- a/lreq/lreq.go
+++ b/lreq/lreq.go
@@ -157,39 +157,6 @@ func unmarshalField(
 	strVal, ok := params[param]
 	strVals, okMulti := multiParam[param]
 
-	//fmt.Println(fmt.Sprintf("ok %t", ok))
-	//fmt.Println(fmt.Sprintf("okMulti %t", okMulti))
-	//fmt.Println(fmt.Sprintf("strVal %s", strVal))
-	//fmt.Println(fmt.Sprintf("strVals %+v", strVals))
-	//
-	//fmt.Println(fmt.Sprintf("strVals == nil %t", strVals == nil))
-	//fmt.Println(fmt.Sprintf("len(strVals) < 1) %t", len(strVals) < 1))
-
-	// check for empty / unset values and return no error if so
-	//if !ok && !okMulti || (strVal == "" && (strVals == nil || len(strVals) < 1) || strVals[0] == "") {
-	//	return nil
-	//}
-
-	//fmt.Println(fmt.Sprintf("param %s", param))
-	//fmt.Println(fmt.Sprintf("params[param] %s", strVal))
-	//fmt.Println(fmt.Sprintf("multiParam[param] %+v", strVals))
-	//fmt.Println(fmt.Sprintf("typeField.Name() %s", typeField.Name()))
-	//fmt.Println(fmt.Sprintf("typeField.Kind() %s", typeField.Kind()))
-	//
-	//if typeField.Kind() == reflect.Array ||
-	//	typeField.Kind() == reflect.Chan ||
-	//	typeField.Kind() == reflect.Map ||
-	//	typeField.Kind() == reflect.Ptr ||
-	//	typeField.Kind() == reflect.Slice {
-	//	fmt.Println(fmt.Sprintf("typeField.Elem() %s", typeField.Elem()))
-	//	fmt.Println(fmt.Sprintf("typeField.Elem().Kind() %s", typeField.Elem().Kind()))
-	//}
-
-	//fmt.Println(fmt.Sprintf("valueField.Type() %s", valueField.Type()))
-	//fmt.Println(fmt.Sprintf("valueField.Kind() %s", valueField.Kind()))
-	//
-	//fmt.Print("\n\n\n")
-
 	switch typeField.Kind() {
 	case reflect.Array:
 		if strVal == "" {

--- a/lreq/lreq_test.go
+++ b/lreq/lreq_test.go
@@ -148,7 +148,7 @@ func Test_UnmarshalReq(t *testing.T) {
 		)
 		require.NoError(t, err)
 	})
-	t.Run("valid input unset values", func(t *testing.T) {
+	t.Run("valid input - mongo ID unset", func(t *testing.T) {
 		var input util.MockListReq
 		err := UnmarshalReq(
 			events.APIGatewayProxyRequest{
@@ -161,7 +161,71 @@ func Test_UnmarshalReq(t *testing.T) {
 		)
 		require.NoError(t, err)
 	})
-
+	t.Run("valid input - mongo ID pointer unset", func(t *testing.T) {
+		var input util.MockListReq
+		err := UnmarshalReq(
+			events.APIGatewayProxyRequest{
+				QueryStringParameters: map[string]string{
+					"mongoIdPtr": "",
+				},
+			},
+			false,
+			&input,
+		)
+		require.NoError(t, err)
+	})
+	t.Run("valid input - time unset", func(t *testing.T) {
+		var input util.MockListReq
+		err := UnmarshalReq(
+			events.APIGatewayProxyRequest{
+				QueryStringParameters: map[string]string{
+					"time": "",
+				},
+			},
+			false,
+			&input,
+		)
+		require.NoError(t, err)
+	})
+	t.Run("valid input - time pointer unset", func(t *testing.T) {
+		var input util.MockListReq
+		err := UnmarshalReq(
+			events.APIGatewayProxyRequest{
+				QueryStringParameters: map[string]string{
+					"timePtr": "",
+				},
+			},
+			false,
+			&input,
+		)
+		require.NoError(t, err)
+	})
+	t.Run("valid input - civil unset", func(t *testing.T) {
+		var input util.MockListReq
+		err := UnmarshalReq(
+			events.APIGatewayProxyRequest{
+				QueryStringParameters: map[string]string{
+					"civil": "",
+				},
+			},
+			false,
+			&input,
+		)
+		require.NoError(t, err)
+	})
+	t.Run("valid input - civil pointer unset", func(t *testing.T) {
+		var input util.MockListReq
+		err := UnmarshalReq(
+			events.APIGatewayProxyRequest{
+				QueryStringParameters: map[string]string{
+					"civilPtr": "",
+				},
+			},
+			false,
+			&input,
+		)
+		require.NoError(t, err)
+	})
 	t.Run("invalid path&query input", func(t *testing.T) {
 		var input util.MockListReq
 		err := UnmarshalReq(


### PR DESCRIPTION
* return nil when strings are unset for time.Time, civil.Date, and primitive.ObjectID types. - closes #44 
* add tests to check for empty mongo id, empty mongo pointer id, empty civil date, empty civil date pointer, empty time, empty time pointer